### PR TITLE
jasonboukheir/issue11

### DIFF
--- a/Packages/com.careboo.blinq/CareBoo.Blinq.Tests/GroupByTest.cs
+++ b/Packages/com.careboo.blinq/CareBoo.Blinq.Tests/GroupByTest.cs
@@ -1,0 +1,36 @@
+﻿using static ValueFuncs;
+using static Utils;
+using NUnit.Framework;
+using Unity.Collections;
+using Linq = System.Linq.Enumerable;
+using Blinq = CareBoo.Blinq.Sequence;
+using CareBoo.Blinq;
+
+internal class GroupByTest
+{
+    internal struct SelectGroupingFunc : IFunc<int, NativeMultiHashMap<int, int>, int>
+    {
+        public int Invoke(int arg0, NativeMultiHashMap<int, int> arg1) => arg0 + arg1.CountValuesForKey(arg0);
+    }
+
+    internal readonly static ValueFunc<int, NativeMultiHashMap<int, int>, int>.Impl<SelectGroupingFunc> SelectGrouping =
+        ValueFunc<int, NativeMultiHashMap<int, int>, int>.CreateImpl<SelectGroupingFunc>();
+
+    [Test, Parallelizable]
+    public void BlinqShouldEqualLinqNativeArrayGroupBy([ArrayValues] int[] sourceArr)
+    {
+        var source = new NativeArray<int>(sourceArr, Allocator.Persistent);
+        var expected = ExceptionAndValue(() =>
+        {
+            var groupBy = Linq.GroupBy(source, SelectSelf<int>().Invoke, (key, values) => key + Linq.Count(values));
+            return Linq.ToArray(groupBy);
+        });
+        var actual = ExceptionAndValue(() =>
+        {
+            var groupBy = Blinq.GroupBy(ref source, SelectSelf<int>(), SelectGrouping);
+            return Linq.ToArray(groupBy);
+        });
+        AssertAreEqual(expected, actual);
+        source.Dispose();
+    }
+}

--- a/Packages/com.careboo.blinq/CareBoo.Blinq.Tests/GroupByTest.cs.meta
+++ b/Packages/com.careboo.blinq/CareBoo.Blinq.Tests/GroupByTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4cc8708bb8bf4bd47828f16a0a32ce67
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.careboo.blinq/CareBoo.Blinq/NativeArray/NativeArray.GroupBy.cs
+++ b/Packages/com.careboo.blinq/CareBoo.Blinq/NativeArray/NativeArray.GroupBy.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using Unity.Collections;
+
+namespace CareBoo.Blinq
+{
+    public static partial class Sequence
+    {
+        public static ValueSequence<TResult, GroupBySequence<T, NativeArraySequence<T>, TKey, TKeySelector, TElement, TElementSelector, TResult, TResultSelector>> GroupBy<T, TKey, TKeySelector, TElement, TElementSelector, TResult, TResultSelector>(
+            this ref NativeArray<T> source,
+            ValueFunc<T, TKey>.Impl<TKeySelector> keySelector,
+            ValueFunc<T, TElement>.Impl<TElementSelector> elementSelector,
+            ValueFunc<TKey, NativeMultiHashMap<TKey, TElement>, TResult>.Impl<TResultSelector> resultSelector
+            )
+            where T : struct
+            where TKey : unmanaged, IEquatable<TKey>
+            where TKeySelector : struct, IFunc<T, TKey>
+            where TElement : struct
+            where TElementSelector : struct, IFunc<T, TElement>
+            where TResult : struct
+            where TResultSelector : struct, IFunc<TKey, NativeMultiHashMap<TKey, TElement>, TResult>
+        {
+            return source.ToValueSequence().GroupBy(keySelector, elementSelector, resultSelector);
+        }
+
+        // public static ValueSequence<ValueGrouping<TKey, TElement>, GroupBySequence<T, NativeArraySequence<T>, TKey, TKeySelector, TElement, TElementSelector, ValueGrouping<TKey, TElement>, GroupingSelector<TKey, TElement>>> GroupBy<T, TKey, TKeySelector, TElement, TElementSelector>(
+        //     this ref NativeArray<T> source,
+        //     ValueFunc<T, TKey>.Impl<TKeySelector> keySelector,
+        //     ValueFunc<T, TElement>.Impl<TElementSelector> elementSelector
+        //     )
+        //     where T : struct
+        //     where TKey : struct, IEquatable<TKey>
+        //     where TKeySelector : struct, IFunc<T, TKey>
+        //     where TElement : struct
+        //     where TElementSelector : struct, IFunc<T, TElement>
+        // {
+        //     return source.ToValueSequence().GroupBy(keySelector, elementSelector);
+        // }
+
+        public static ValueSequence<TResult, GroupBySequence<T, NativeArraySequence<T>, TKey, TKeySelector, T, SameSelector<T>, TResult, TResultSelector>> GroupBy<T, TKey, TKeySelector, TResult, TResultSelector>(
+            this ref NativeArray<T> source,
+            ValueFunc<T, TKey>.Impl<TKeySelector> keySelector,
+            ValueFunc<TKey, NativeMultiHashMap<TKey, T>, TResult>.Impl<TResultSelector> resultSelector
+            )
+            where T : struct
+            where TKey : unmanaged, IEquatable<TKey>
+            where TKeySelector : struct, IFunc<T, TKey>
+            where TResult : struct
+            where TResultSelector : struct, IFunc<TKey, NativeMultiHashMap<TKey, T>, TResult>
+        {
+            return source.ToValueSequence().GroupBy(keySelector, resultSelector);
+        }
+
+        // public static ValueSequence<ValueGrouping<TKey, T>, GroupBySequence<T, NativeArraySequence<T>, TKey, TKeySelector, T, SameSelector<T>, ValueGrouping<TKey, T>, GroupingSelector<TKey, T>>> GroupBy<T, TKey, TKeySelector>(
+        //     this ref NativeArray<T> source,
+        //     ValueFunc<T, TKey>.Impl<TKeySelector> keySelector
+        //     )
+        //     where T : struct
+        //     where TKey : struct, IEquatable<TKey>
+        //     where TKeySelector : struct, IFunc<T, TKey>
+        // {
+        //     return source.ToValueSequence().GroupBy(keySelector);
+        // }
+    }
+}

--- a/Packages/com.careboo.blinq/CareBoo.Blinq/NativeArray/NativeArray.GroupBy.cs.meta
+++ b/Packages/com.careboo.blinq/CareBoo.Blinq/NativeArray/NativeArray.GroupBy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 67ab82860fbdc0f4e8c66db3c5eb0091
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.careboo.blinq/CareBoo.Blinq/NativeArray/NativeArray.SelectMany.cs
+++ b/Packages/com.careboo.blinq/CareBoo.Blinq/NativeArray/NativeArray.SelectMany.cs
@@ -32,7 +32,7 @@ namespace CareBoo.Blinq
             return source.ToValueSequence().SelectMany(collectionSelector, resultSelector);
         }
 
-        public static ValueSequence<TResult, SelectManySequence<T, NativeArraySequence<T>, TResult, TResult, TSelector, NoneResultSelector<T, TResult>>> SelectMany<T, TResult, TSelector>(
+        public static ValueSequence<TResult, SelectManySequence<T, NativeArraySequence<T>, TResult, TResult, TSelector, RightSelector<T, TResult>>> SelectMany<T, TResult, TSelector>(
             this ref NativeArray<T> source,
             ValueFunc<T, NativeArray<TResult>>.Impl<TSelector> selector
             )
@@ -43,7 +43,7 @@ namespace CareBoo.Blinq
             return source.ToValueSequence().SelectMany(selector);
         }
 
-        public static ValueSequence<TResult, SelectManyIndexSequence<T, NativeArraySequence<T>, TResult, TResult, TSelector, NoneResultSelector<T, TResult>>> SelectMany<T, TResult, TSelector>(
+        public static ValueSequence<TResult, SelectManyIndexSequence<T, NativeArraySequence<T>, TResult, TResult, TSelector, RightSelector<T, TResult>>> SelectMany<T, TResult, TSelector>(
             this ref NativeArray<T> source,
             ValueFunc<T, int, NativeArray<TResult>>.Impl<TSelector> selector
             )

--- a/Packages/com.careboo.blinq/CareBoo.Blinq/SameSelector.cs
+++ b/Packages/com.careboo.blinq/CareBoo.Blinq/SameSelector.cs
@@ -1,0 +1,31 @@
+﻿namespace CareBoo.Blinq
+{
+    public struct RightSelector<T, TResult>
+        : IFunc<T, TResult, TResult>
+        where T : struct
+        where TResult : struct
+    {
+        public TResult Invoke(T arg0, TResult arg1)
+        {
+            return arg1;
+        }
+    }
+
+    public struct LeftSelector<T, TResult>
+        : IFunc<T, TResult, T>
+        where T : struct
+        where TResult : struct
+    {
+        public T Invoke(T arg0, TResult arg1)
+        {
+            return arg0;
+        }
+    }
+
+    public struct SameSelector<T>
+        : IFunc<T, T>
+        where T : struct
+    {
+        public T Invoke(T arg0) => arg0;
+    }
+}

--- a/Packages/com.careboo.blinq/CareBoo.Blinq/SameSelector.cs.meta
+++ b/Packages/com.careboo.blinq/CareBoo.Blinq/SameSelector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ec85e71345600b649a323b701d62dfc6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.careboo.blinq/CareBoo.Blinq/UtilFunctions.cs
+++ b/Packages/com.careboo.blinq/CareBoo.Blinq/UtilFunctions.cs
@@ -1,0 +1,25 @@
+﻿namespace CareBoo.Blinq
+{
+    public static class UtilFunctions
+    {
+        public static ValueFunc<T, TResult, TResult>.Impl<RightSelector<T, TResult>> RightSelector<T, TResult>()
+            where T : struct
+            where TResult : struct
+        {
+            return ValueFunc<T, TResult, TResult>.CreateImpl<RightSelector<T, TResult>>();
+        }
+
+        public static ValueFunc<T, TResult, T>.Impl<LeftSelector<T, TResult>> LeftSelector<T, TResult>()
+            where T : struct
+            where TResult : struct
+        {
+            return ValueFunc<T, TResult, T>.CreateImpl<LeftSelector<T, TResult>>();
+        }
+
+        public static ValueFunc<T, T>.Impl<SameSelector<T>> SameSelector<T>()
+            where T : struct
+        {
+            return ValueFunc<T, T>.CreateImpl<SameSelector<T>>();
+        }
+    }
+}

--- a/Packages/com.careboo.blinq/CareBoo.Blinq/UtilFunctions.cs.meta
+++ b/Packages/com.careboo.blinq/CareBoo.Blinq/UtilFunctions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c404398e50babc04dad57f25ce9997f2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.careboo.blinq/CareBoo.Blinq/ValueGrouping.cs
+++ b/Packages/com.careboo.blinq/CareBoo.Blinq/ValueGrouping.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Unity.Collections;
+
+namespace CareBoo.Blinq
+{
+    public struct ValueGrouping<TKey, TElement>
+        : IGrouping<TKey, TElement>
+        where TKey : struct, IEquatable<TKey>
+        where TElement : struct
+    {
+        readonly TKey key;
+        readonly NativeMultiHashMap<TKey, TElement> groupMap;
+
+        public TKey Key => key;
+
+        public ValueGrouping(in TKey key, in NativeMultiHashMap<TKey, TElement> groupMap)
+        {
+            this.key = key;
+            this.groupMap = groupMap;
+        }
+
+        public NativeMultiHashMap<TKey, TElement>.Enumerator GetEnumerator()
+        {
+            return groupMap.GetValuesForKey(key);
+        }
+
+        IEnumerator<TElement> IEnumerable<TElement>.GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public static class ValueGrouping
+    {
+        public static ValueGrouping<TKey, TElement> New<TKey, TElement>(
+            in TKey key,
+            in NativeMultiHashMap<TKey, TElement> groupMap
+            )
+            where TKey : struct, IEquatable<TKey>
+            where TElement : struct
+        {
+            return new ValueGrouping<TKey, TElement>(key, groupMap);
+        }
+    }
+}

--- a/Packages/com.careboo.blinq/CareBoo.Blinq/ValueGrouping.cs.meta
+++ b/Packages/com.careboo.blinq/CareBoo.Blinq/ValueGrouping.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5e644eb3dd56a0446a3f6f43ace4999d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.careboo.blinq/CareBoo.Blinq/ValueSequence/ValueSequence.GroupBy.cs
+++ b/Packages/com.careboo.blinq/CareBoo.Blinq/ValueSequence/ValueSequence.GroupBy.cs
@@ -1,0 +1,181 @@
+﻿using System;
+using Unity.Burst;
+using Unity.Collections;
+
+namespace CareBoo.Blinq
+{
+    public static partial class Sequence
+    {
+        public static ValueSequence<TResult, GroupBySequence<T, TSource, TKey, TKeySelector, TElement, TElementSelector, TResult, TResultSelector>> GroupBy<T, TSource, TKey, TKeySelector, TElement, TElementSelector, TResult, TResultSelector>(
+            this ValueSequence<T, TSource> source,
+            ValueFunc<T, TKey>.Impl<TKeySelector> keySelector,
+            ValueFunc<T, TElement>.Impl<TElementSelector> elementSelector,
+            ValueFunc<TKey, NativeMultiHashMap<TKey, TElement>, TResult>.Impl<TResultSelector> resultSelector
+            )
+            where T : struct
+            where TSource : struct, ISequence<T>
+            where TKey : unmanaged, IEquatable<TKey>
+            where TKeySelector : struct, IFunc<T, TKey>
+            where TElement : struct
+            where TElementSelector : struct, IFunc<T, TElement>
+            where TResult : struct
+            where TResultSelector : struct, IFunc<TKey, NativeMultiHashMap<TKey, TElement>, TResult>
+        {
+            var seq = GroupBySequence.New(source.Source, keySelector, elementSelector, resultSelector);
+            return ValueSequence<TResult>.New(seq);
+        }
+
+        // public static ValueSequence<ValueGrouping<TKey, TElement>, GroupBySequence<T, TSource, TKey, TKeySelector, TElement, TElementSelector, ValueGrouping<TKey, TElement>, GroupingSelector<TKey, TElement>>> GroupBy<T, TSource, TKey, TKeySelector, TElement, TElementSelector>(
+        //     this ValueSequence<T, TSource> source,
+        //     ValueFunc<T, TKey>.Impl<TKeySelector> keySelector,
+        //     ValueFunc<T, TElement>.Impl<TElementSelector> elementSelector
+        //     )
+        //     where T : struct
+        //     where TSource : struct, ISequence<T>
+        //     where TKey : struct, IEquatable<TKey>
+        //     where TKeySelector : struct, IFunc<T, TKey>
+        //     where TElement : struct
+        //     where TElementSelector : struct, IFunc<T, TElement>
+        // {
+        //     var resultSelector = ValueFunc<TKey, NativeMultiHashMap<TKey, TElement>, ValueGrouping<TKey, TElement>>.CreateImpl<GroupingSelector<TKey, TElement>>();
+        //     return source.GroupBy(keySelector, elementSelector, resultSelector);
+        // }
+
+        public static ValueSequence<TResult, GroupBySequence<T, TSource, TKey, TKeySelector, T, SameSelector<T>, TResult, TResultSelector>> GroupBy<T, TSource, TKey, TKeySelector, TResult, TResultSelector>(
+            this ValueSequence<T, TSource> source,
+            ValueFunc<T, TKey>.Impl<TKeySelector> keySelector,
+            ValueFunc<TKey, NativeMultiHashMap<TKey, T>, TResult>.Impl<TResultSelector> resultSelector
+            )
+            where T : struct
+            where TSource : struct, ISequence<T>
+            where TKey : unmanaged, IEquatable<TKey>
+            where TKeySelector : struct, IFunc<T, TKey>
+            where TResult : struct
+            where TResultSelector : struct, IFunc<TKey, NativeMultiHashMap<TKey, T>, TResult>
+        {
+            var elementSelector = UtilFunctions.SameSelector<T>();
+            return source.GroupBy(keySelector, elementSelector, resultSelector);
+        }
+
+        // public static ValueSequence<ValueGrouping<TKey, T>, GroupBySequence<T, TSource, TKey, TKeySelector, T, SameSelector<T>, ValueGrouping<TKey, T>, GroupingSelector<TKey, T>>> GroupBy<T, TSource, TKey, TKeySelector>(
+        //     this ValueSequence<T, TSource> source,
+        //     ValueFunc<T, TKey>.Impl<TKeySelector> keySelector
+        //     )
+        //     where T : struct
+        //     where TSource : struct, ISequence<T>
+        //     where TKey : struct, IEquatable<TKey>
+        //     where TKeySelector : struct, IFunc<T, TKey>
+        // {
+        //     var elementSelector = UtilFunctions.SameSelector<T>();
+        //     var resultSelector = ValueFunc<TKey, NativeMultiHashMap<TKey, T>, ValueGrouping<TKey, T>>.CreateImpl<GroupingSelector<TKey, T>>();
+        //     return source.GroupBy(keySelector, elementSelector, resultSelector);
+        // }
+    }
+
+    public struct GroupBySequence<T, TSource, TKey, TKeySelector, TElement, TElementSelector, TResult, TResultSelector>
+        : ISequence<TResult>
+        where T : struct
+        where TSource : struct, ISequence<T>
+        where TKey : unmanaged, IEquatable<TKey>
+        where TKeySelector : struct, IFunc<T, TKey>
+        where TElement : struct
+        where TElementSelector : struct, IFunc<T, TElement>
+        where TResult : struct
+        where TResultSelector : struct, IFunc<TKey, NativeMultiHashMap<TKey, TElement>, TResult>
+    {
+        readonly TSource source;
+        readonly ValueFunc<T, TKey>.Impl<TKeySelector> keySelector;
+        readonly ValueFunc<T, TElement>.Impl<TElementSelector> elementSelector;
+        readonly ValueFunc<TKey, NativeMultiHashMap<TKey, TElement>, TResult>.Impl<TResultSelector> resultSelector;
+
+        public GroupBySequence(
+            TSource source,
+            ValueFunc<T, TKey>.Impl<TKeySelector> keySelector,
+            ValueFunc<T, TElement>.Impl<TElementSelector> elementSelector,
+            ValueFunc<TKey, NativeMultiHashMap<TKey, TElement>, TResult>.Impl<TResultSelector> resultSelector
+            )
+        {
+            this.source = source;
+            this.keySelector = keySelector;
+            this.elementSelector = elementSelector;
+            this.resultSelector = resultSelector;
+        }
+
+        public NativeList<TResult> Execute()
+        {
+            using (var srcList = source.Execute())
+            using (var groupMap = new NativeMultiHashMap<TKey, TElement>(srcList.Length, Allocator.Temp))
+            {
+                return Execute(srcList, groupMap);
+            }
+        }
+
+        public NativeList<TResult> Execute(NativeList<T> srcList, NativeMultiHashMap<TKey, TElement> groupMap)
+        {
+            var results = new NativeList<TResult>(Allocator.Temp);
+            AddElementsToGroupMap(srcList, groupMap);
+            EnumerateGroupsAndAddToResults(groupMap, results);
+            return results;
+        }
+
+        private void AddElementsToGroupMap(NativeList<T> srcList, NativeMultiHashMap<TKey, TElement> groupMap)
+        {
+            for (var i = 0; i < srcList.Length; i++)
+            {
+                var item = srcList[i];
+                var key = keySelector.Invoke(item);
+                var element = elementSelector.Invoke(item);
+                groupMap.Add(key, element);
+            }
+        }
+
+        private void EnumerateGroupsAndAddToResults(NativeMultiHashMap<TKey, TElement> groupMap, NativeList<TResult> results)
+        {
+            using (var keysArr = groupMap.GetKeyArray(Allocator.Temp))
+            using (var keySet = new NativeHashSet<TKey>(keysArr.Length, Allocator.Temp))
+            {
+                for (var i = 0; i < keysArr.Length; i++)
+                {
+                    var key = keysArr[i];
+                    if (keySet.Add(key))
+                    {
+                        var result = resultSelector.Invoke(key, groupMap);
+                        results.Add(result);
+                    }
+                }
+            }
+        }
+    }
+
+    public static class GroupBySequence
+    {
+        public static GroupBySequence<T, TSource, TKey, TKeySelector, TElement, TElementSelector, TResult, TResultSelector> New<T, TSource, TKey, TKeySelector, TElement, TElementSelector, TResult, TResultSelector>(
+            TSource source,
+            ValueFunc<T, TKey>.Impl<TKeySelector> keySelector,
+            ValueFunc<T, TElement>.Impl<TElementSelector> elementSelector,
+            ValueFunc<TKey, NativeMultiHashMap<TKey, TElement>, TResult>.Impl<TResultSelector> resultSelector
+            )
+            where T : struct
+            where TSource : struct, ISequence<T>
+            where TKey : unmanaged, IEquatable<TKey>
+            where TKeySelector : struct, IFunc<T, TKey>
+            where TElement : struct
+            where TElementSelector : struct, IFunc<T, TElement>
+            where TResult : struct
+            where TResultSelector : struct, IFunc<TKey, NativeMultiHashMap<TKey, TElement>, TResult>
+        {
+            return new GroupBySequence<T, TSource, TKey, TKeySelector, TElement, TElementSelector, TResult, TResultSelector>(source, keySelector, elementSelector, resultSelector);
+        }
+    }
+
+    public struct GroupingSelector<TKey, TElement>
+        : IFunc<TKey, NativeMultiHashMap<TKey, TElement>, ValueGrouping<TKey, TElement>>
+        where TKey : unmanaged, IEquatable<TKey>
+        where TElement : struct
+    {
+        public ValueGrouping<TKey, TElement> Invoke(TKey arg0, NativeMultiHashMap<TKey, TElement> arg1)
+        {
+            return ValueGrouping.New(arg0, arg1);
+        }
+    }
+}

--- a/Packages/com.careboo.blinq/CareBoo.Blinq/ValueSequence/ValueSequence.GroupBy.cs.meta
+++ b/Packages/com.careboo.blinq/CareBoo.Blinq/ValueSequence/ValueSequence.GroupBy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1a15aad4121538b4793bb3898d6b755c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.careboo.blinq/CareBoo.Blinq/ValueSequence/ValueSequence.SelectMany.cs
+++ b/Packages/com.careboo.blinq/CareBoo.Blinq/ValueSequence/ValueSequence.SelectMany.cs
@@ -36,7 +36,7 @@ namespace CareBoo.Blinq
             return ValueSequence<TResult>.New(seq);
         }
 
-        public static ValueSequence<TResult, SelectManySequence<T, TSource, TResult, TResult, TSelector, NoneResultSelector<T, TResult>>> SelectMany<T, TSource, TResult, TSelector>(
+        public static ValueSequence<TResult, SelectManySequence<T, TSource, TResult, TResult, TSelector, RightSelector<T, TResult>>> SelectMany<T, TSource, TResult, TSelector>(
             this ValueSequence<T, TSource> source,
             ValueFunc<T, NativeArray<TResult>>.Impl<TSelector> selector
             )
@@ -45,11 +45,11 @@ namespace CareBoo.Blinq
             where TResult : struct
             where TSelector : struct, IFunc<T, NativeArray<TResult>>
         {
-            var seq = SelectManySequence.New(source.Source, selector, ValueFunc<T, TResult, TResult>.CreateImpl<NoneResultSelector<T, TResult>>());
+            var seq = SelectManySequence.New(source.Source, selector, UtilFunctions.RightSelector<T, TResult>());
             return ValueSequence<TResult>.New(seq);
         }
 
-        public static ValueSequence<TResult, SelectManyIndexSequence<T, TSource, TResult, TResult, TSelector, NoneResultSelector<T, TResult>>> SelectMany<T, TSource, TResult, TSelector>(
+        public static ValueSequence<TResult, SelectManyIndexSequence<T, TSource, TResult, TResult, TSelector, RightSelector<T, TResult>>> SelectMany<T, TSource, TResult, TSelector>(
             this ValueSequence<T, TSource> source,
             ValueFunc<T, int, NativeArray<TResult>>.Impl<TSelector> selector
             )
@@ -58,7 +58,7 @@ namespace CareBoo.Blinq
             where TResult : struct
             where TSelector : struct, IFunc<T, int, NativeArray<TResult>>
         {
-            var seq = SelectManySequence.New(source.Source, selector, ValueFunc<T, TResult, TResult>.CreateImpl<NoneResultSelector<T, TResult>>());
+            var seq = SelectManySequence.New(source.Source, selector, UtilFunctions.RightSelector<T, TResult>());
             return ValueSequence<TResult>.New(seq);
         }
     }
@@ -201,17 +201,6 @@ namespace CareBoo.Blinq
             where TResultSelector : struct, IFunc<T, TCollection, TResult>
         {
             return new SelectManyIndexSequence<T, TSource, TCollection, TResult, TCollectionSelector, TResultSelector>(source, collectionSelector, resultSelector);
-        }
-    }
-
-    public struct NoneResultSelector<T, TResult>
-        : IFunc<T, TResult, TResult>
-        where T : struct
-        where TResult : struct
-    {
-        public TResult Invoke(T arg0, TResult arg1)
-        {
-            return arg1;
         }
     }
 }


### PR DESCRIPTION

We're not allowed to have NativeContainer of NativeContainer, so there isn't a simple way to implement ValueGrouping. This is real unfortunate.

Fixes #11